### PR TITLE
Fix bugs, security issues, and code quality from master branch review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Copy this file to .env and fill in your values
 DISCORD_TOKEN = your_discord_bot_token_here
+LAVALINK_PASSWORD = changeme123

--- a/Cogs/cpu.py
+++ b/Cogs/cpu.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
-from discord.utils import get
 import discord
+import asyncio
 import psutil
 
 
@@ -8,7 +8,7 @@ class cpu(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(name='serverinfo', description="Permanant server hardware information")
+    @commands.command(name='serverinfo', description="Permanent server hardware information")
     async def server_info(self, ctx):
         embed = discord.Embed(color=discord.Color.blurple())
         embed.title = 'Server Information'
@@ -25,8 +25,8 @@ class cpu(commands.Cog):
     async def cpu_info(self, ctx):
         embed = discord.Embed(color=discord.Color.blurple())
         embed.title = 'CPU Information'
-        embed.description = str(psutil.cpu_percent(
-            interval=1)) + "% CPU Usage \n"
+        cpu_percent = await asyncio.to_thread(psutil.cpu_percent, 1)
+        embed.description = str(cpu_percent) + "% CPU Usage \n"
 
         try:
             temps = psutil.sensors_temperatures(fahrenheit=False)

--- a/Cogs/music.py
+++ b/Cogs/music.py
@@ -1,3 +1,4 @@
+import os
 import re
 import random
 import discord
@@ -14,6 +15,7 @@ url_rx = re.compile(r'https?://(?:www\.)?.+')
 config = fileProcessing.read_config()
 roles = config["roles"]
 voice_permissions_check_list = config["voice_permission_check_list"]
+lavalink_password = os.getenv('LAVALINK_PASSWORD', 'changeme123')
 
 
 class LavalinkVoiceClient(discord.VoiceProtocol):
@@ -28,7 +30,7 @@ class LavalinkVoiceClient(discord.VoiceProtocol):
             self.client.lavalink.add_node(
                 host='localhost',
                 port=2333,
-                password='changeme123',
+                password=lavalink_password,
                 region='us',
                 name='default-node'
             )
@@ -91,11 +93,12 @@ class LavalinkVoiceClient(discord.VoiceProtocol):
 class music(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        self._auto_unpause_guilds: set = set()
 
         if not hasattr(bot, 'lavalink'):
             bot.lavalink = lavalink.Client(bot.user.id)
             bot.lavalink.add_node(
-                host='127.0.0.1', port=2333, password='changeme123', region='us', name='default-node')
+                host='127.0.0.1', port=2333, password=lavalink_password, region='us', name='default-node')
 
         self.lavalink: lavalink.Client = bot.lavalink
         self.lavalink.add_event_hooks(self)
@@ -193,7 +196,7 @@ class music(commands.Cog):
     async def play_from_list(self, ctx, *, playlist_name):
         fileProcessing.logUpdate(ctx, playlist_name)
         songlist = fileProcessing.play_playlist(ctx, playlist_name)
-        if songlist == False:
+        if songlist is False:
             return await ctx.send("Playlist not found.")
         await ctx.invoke(self.bot.get_command('play'), query=songlist[0])
         songlist.pop(0)
@@ -221,18 +224,16 @@ class music(commands.Cog):
     async def skip_song(self, ctx, amount: int = 1):
         try:
             player = self.bot.lavalink.player_manager.get(ctx.guild.id)
-            while (amount > 0):
+            while amount > 0:
                 amount -= 1
                 if not player.is_playing:
-                    raise commands.CommandInvokeError(
-                        "Nothing playing to skip.")
-                else:
-                    if amount % 2 == 0:
-                        await asyncio.sleep(.1)
-                    await player.skip()
-                    if amount == 0:
-                        await ctx.send("Song skipped.")
-        except:
+                    raise commands.CommandInvokeError("Nothing playing to skip.")
+                if amount % 2 == 0:
+                    await asyncio.sleep(.1)
+                await player.skip()
+                if amount == 0:
+                    await ctx.send("Song skipped.")
+        except Exception:
             if amount > 0:
                 return await ctx.send("All songs skipped")
 
@@ -255,26 +256,28 @@ class music(commands.Cog):
     @commands.command(name='pause', aliases=["ps"], description="Pauses a song if one is playing.")
     @commands.has_any_role(*roles)
     async def pause_bot(self, ctx):
-        try:
-            player = self.bot.lavalink.player_manager.get(ctx.guild.id)
-            if player.is_playing:
-                status = True
-                await ctx.send("Song has been paused.")
-                await player.set_pause(True)
-                for i in range(84):
-                    await asyncio.sleep(5)
-                    if not player.paused:
-                        status = False
-                        break
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
+        if not player:
+            raise commands.CommandInvokeError("Unable to retrieve player...")
+        if not player.is_playing:
+            return await ctx.send("No song is playing to be paused.")
+        if ctx.guild.id in self._auto_unpause_guilds:
+            return await ctx.send("Song is already paused.")
 
-                if player.paused and player.is_playing and status is True:
+        self._auto_unpause_guilds.add(ctx.guild.id)
+        await player.set_pause(True)
+        await ctx.send("Song has been paused.")
+        try:
+            for _ in range(84):
+                await asyncio.sleep(5)
+                if not player.paused:
+                    break
+            else:
+                if player.is_playing:
                     await player.set_pause(False)
                     await ctx.send("Automatically unpaused.")
-
-            else:
-                await ctx.send("No song is playing to be paused.")
-        except:
-            raise commands.CommandInvokeError("Unable to retrieve player...")
+        finally:
+            self._auto_unpause_guilds.discard(ctx.guild.id)
 
     @commands.command(name='unpause', aliases=['resume', 'start', 'up'], description="Unpauses a paused song.")
     @commands.has_any_role(*roles)
@@ -335,24 +338,13 @@ class music(commands.Cog):
     @commands.command(name="shuffle", description="Shuffles the current queue.")
     @commands.has_any_role(*roles)
     async def shuffle(self, ctx):
-        try:
-            player = self.bot.lavalink.player_manager.get(ctx.guild.id)
-            if player.is_playing:
-                songlist = player.queue
-                size = len(songlist)
-                for x in range(0, size):
-                    if (x % 8 == 0):
-                        await asyncio.sleep(0.1)
-                    temp = songlist[x]
-                    randnum = random.randint(0, size - 1)
-                    songlist[x] = songlist[randnum]
-                    songlist[randnum] = temp
-                await ctx.send("Finished.")
-            else:
-                raise commands.CommandInvokeError("Nothing playing!")
-
-        except Exception:
-            await ctx.send("Shuffle failed. Nothing may be queued.")
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
+        if not player or not player.is_playing:
+            return await ctx.send("Nothing playing to shuffle.")
+        if not player.queue:
+            return await ctx.send("Nothing queued to shuffle.")
+        random.shuffle(player.queue)
+        await ctx.send("Finished.")
 
     @commands.command(name='removequeue', aliases=['rq'], description="Removes a song from the queue by its position number.")
     @commands.has_any_role(*roles)

--- a/bot.py
+++ b/bot.py
@@ -18,10 +18,12 @@ client = commands.Bot(command_prefix='.', intents=intents)
 @client.event
 async def on_ready():
     print("Bot is live")
-    await client.load_extension('playlist')
-    for file in os.listdir("./Cogs"):
-        if file.endswith(".py"):
-            await client.load_extension(f'Cogs.{file[:-3]}')
+    extensions_to_load = ['playlist'] + [
+        f'Cogs.{f[:-3]}' for f in os.listdir("./Cogs") if f.endswith(".py")
+    ]
+    for ext in extensions_to_load:
+        if ext not in client.extensions:
+            await client.load_extension(ext)
 
 # TODO: Refactor so that shell files can go into a folder
 
@@ -45,7 +47,10 @@ async def backup_playlists(ctx):
     waitCounter = 10
     while outcome.poll() is None and waitCounter > 0:
         await asyncio.sleep(1)
-        waitCounter = waitCounter - 1
+        waitCounter -= 1
+
+    if outcome.returncode != 0:
+        return await ctx.send("Backup failed.")
 
     if os.path.isfile(backup_path):
         await ctx.author.send(file=discord.File(backup_path))

--- a/fileProcessing.py
+++ b/fileProcessing.py
@@ -1,14 +1,17 @@
 import json
+import os
 import os.path
 from os import path
 
 
+def _playlist_path(ctx) -> str:
+    return os.path.join("Playlist", f"{ctx.author.id}.json")
+
+
 def logUpdate(ctx, songName):
-    user_file = os.path.join("SongLog", str(ctx.author.id))
-    user_file = str(user_file) + ".txt"
-    user_write = open(user_file, "a")
-    user_write.write(str(songName) + "\n")
-    user_write.close()
+    user_file = os.path.join("SongLog", f"{ctx.author.id}.txt")
+    with open(user_file, "a") as f:
+        f.write(str(songName) + "\n")
 
 
 def page_format(raw_input) -> list:
@@ -28,8 +31,7 @@ def page_format(raw_input) -> list:
 
 
 def playlist_read(listname, ctx):
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
+    userpath = _playlist_path(ctx)
     i = 1
     try:
         with open(userpath, "r") as fileRead:
@@ -40,13 +42,12 @@ def playlist_read(listname, ctx):
                 final += str(i) + ": " + item + "\n"
                 i = i + 1
             return page_format(final)
-    except:
+    except (FileNotFoundError, KeyError, json.JSONDecodeError):
         return []
 
 
 def list_playlists(ctx):
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
+    userpath = _playlist_path(ctx)
     i = 1
     final = ""
     try:
@@ -57,22 +58,17 @@ def list_playlists(ctx):
                 i = i + 1
 
             return page_format(final)
-    except:
+    except (FileNotFoundError, json.JSONDecodeError):
         return []
-
-# function to create a new playlist in the JSON file or make a JSON file if none exists for the user
 
 
 def new_playlist(ctx, playlist_name, now_playing):
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
+    userpath = _playlist_path(ctx)
     if path.exists(userpath):
         with open(userpath, "r") as read_file:
             data = json.load(read_file)
-            temp = [now_playing]
-            data[playlist_name] = temp
-            dataFinal = json.dumps(data, indent=1)
-            write_out(ctx, dataFinal)
+            data[playlist_name] = [now_playing]
+            write_out(ctx, json.dumps(data, indent=1))
     else:
         dataStart = {playlist_name: [now_playing]}
         with open(userpath, "w") as write_file:
@@ -80,109 +76,84 @@ def new_playlist(ctx, playlist_name, now_playing):
 
 
 def write_out(ctx, data):
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
-    file = open(userpath, "w")
-    file.write(data)
-    file.close()
+    userpath = _playlist_path(ctx)
+    with open(userpath, "w") as f:
+        f.write(data)
 
 
 def delete_playlist(ctx, playlist_name):
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
+    userpath = _playlist_path(ctx)
     if path.exists(userpath):
-        with open(userpath, "r") as read_file:
-            data = json.load(read_file)
-            try:
-                data.pop(playlist_name)
-                dataFinal = json.dumps(data, indent=1)
-                write_out(ctx, dataFinal)
-                return "Done"
-            except:
-                return "Not-Found"
+        try:
+            with open(userpath, "r") as read_file:
+                data = json.load(read_file)
+            data.pop(playlist_name)
+            write_out(ctx, json.dumps(data, indent=1))
+            return "Done"
+        except KeyError:
+            return "Not-Found"
+        except (json.JSONDecodeError, OSError):
+            return "Not-Found"
     else:
         return "No-Playlists"
 
 
 def delete_from_playlist(ctx, playlist_name, selection):
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
-    if path.exists(userpath):
-        with open(userpath, "r") as read_file:
-            try:
-                data = json.load(read_file)
-                data[playlist_name].pop(selection - 1)
-                dataFinal = json.dumps(data, indent=1)
-                write_out(ctx, dataFinal)
-                return "Done"
-            except:
-                return "Not-Found"
-
-    else:
-        return "No-Playlists"
-
-# Reads json, finds playlists and add song then uses help_newplaylist to write back.
-
-
-def add_to_playlist(ctx, playlist_name, now_playing) -> bool:
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
+    userpath = _playlist_path(ctx)
     if path.exists(userpath):
         try:
             with open(userpath, "r") as read_file:
                 data = json.load(read_file)
-                temp = [now_playing]
-                data[playlist_name] += temp
-                dataFinal = json.dumps(data, indent=1)
-                write_out(ctx, dataFinal)
-                return True
+            data[playlist_name].pop(selection - 1)
+            write_out(ctx, json.dumps(data, indent=1))
+            return "Done"
+        except (KeyError, IndexError, json.JSONDecodeError):
+            return "Not-Found"
+    else:
+        return "No-Playlists"
 
-        except:
+
+def add_to_playlist(ctx, playlist_name, now_playing) -> bool:
+    userpath = _playlist_path(ctx)
+    if path.exists(userpath):
+        try:
+            with open(userpath, "r") as read_file:
+                data = json.load(read_file)
+            data[playlist_name].append(now_playing)
+            write_out(ctx, json.dumps(data, indent=1))
+            return True
+        except (KeyError, json.JSONDecodeError, OSError):
             return False
-
-# loads songs from a playlist to be parsed by the calling function
+    return False
 
 
 def play_playlist(ctx, playlist_name):
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
+    userpath = _playlist_path(ctx)
     if path.exists(userpath):
-        # using with auto closes the file after.
         with open(userpath, "r") as read_file:
             data = json.load(read_file)
             if playlist_name in data:
-                songlist = data[playlist_name]
-                return songlist
-            else:
-                # return false if playlist doesnt exist which will be caught by music.py and output playlist doesnt exist.
-                return False
-    else:
-        return False  # same as above comment
+                return data[playlist_name]
+            return False
+    return False
 
 
-def rename_playlist(ctx, raw_input) -> bool:
-    userpath = os.path.join("Playlist", str(ctx.author.id))
-    userpath = str(userpath) + ".json"
-    splitNames = raw_input.split(',')
-    try:
-        if splitNames[0] is not None and splitNames[1] is not None:
-            data = ""
-            specific = ""
-            try:
-                with open(userpath, "r") as fileRead:
-                    data = json.load(fileRead)
-                    specific = data[splitNames[0].strip()]
-                with open(userpath, "w") as fileRead:
-                    data.pop(splitNames[0].strip())  # pop off old playlist
-                    # store the same data as a new list.
-                    data[splitNames[1].strip()] = specific
-                    dataFinal = json.dumps(data, indent=1)
-                    write_out(ctx, dataFinal)
-                    return "Success"
-            except:
-                return "No-List"
-    except:
+def rename_playlist(ctx, raw_input) -> str:
+    userpath = _playlist_path(ctx)
+    parts = [s.strip() for s in raw_input.split(',')]
+    if len(parts) < 2 or not parts[0] or not parts[1]:
         return "Invalid-Input"
+    try:
+        with open(userpath, "r") as f:
+            data = json.load(f)
+        specific = data.pop(parts[0])
+        data[parts[1]] = specific
+        write_out(ctx, json.dumps(data, indent=1))
+        return "Success"
+    except FileNotFoundError:
+        return "No-List"
+    except (KeyError, json.JSONDecodeError):
+        return "No-List"
 
 
 def read_config():
@@ -191,5 +162,5 @@ def read_config():
         with open(configPath, "r") as fileRead:
             data = json.load(fileRead)
             return data
-    except:
-        raise Exception("Config file not found!")
+    except (FileNotFoundError, json.JSONDecodeError):
+        raise Exception("Config file not found or malformed!")

--- a/playlist.py
+++ b/playlist.py
@@ -1,13 +1,8 @@
 from discord.ext import commands
 import discord
-import lavalink
 import asyncio
-from discord import utils
 from discord import Embed
-import re
 import fileProcessing
-
-url_rx = re.compile(r'https?://(?:www\.)?.+')
 
 config = fileProcessing.read_config()
 roles = config["roles"]
@@ -26,21 +21,20 @@ class playlist(commands.Cog):
     async def view_playlist(self, ctx, *, list_name):
         list_collection = fileProcessing.playlist_read(list_name, ctx)
         if list_collection:
-            embed = Embed()
             double = ''
             x = 1
             for section in list_collection:
                 double += section
 
                 if x % 2 == 0:
-                    embed.description = double
+                    embed = Embed(description=double)
                     await ctx.send(embed=embed)
                     await asyncio.sleep(1)
                     double = ''
-                x = x + 1
+                x += 1
 
             if len(list_collection) % 2 != 0:
-                embed.description = double
+                embed = Embed(description=double)
                 await ctx.send(embed=embed)
         else:
             raise commands.CommandInvokeError(
@@ -56,16 +50,13 @@ class playlist(commands.Cog):
         if list_collection:
             selection = page - 1
             embed = Embed()
-            if int(selection) < 0:
-                list_collection[0] += "'\n' + Page: 1/" + \
-                    str(len(list_collection))
+            if selection < 0:
+                list_collection[0] += "\nPage: 1/" + str(len(list_collection))
                 embed.description = list_collection[0]
-
-            elif int(selection) > len(list_collection) - 1:
-                list_collection[len(list_collection) - 1] += "'\n' + Page: " + str(
+            elif selection > len(list_collection) - 1:
+                list_collection[len(list_collection) - 1] += "\nPage: " + str(
                     len(list_collection)) + "/" + str(len(list_collection))
-                embed.description = list_collection[len(
-                    list_collection) - 1]
+                embed.description = list_collection[len(list_collection) - 1]
             else:
                 list_collection[selection] += '\n' + "Page: " + \
                     str(page) + "/" + str(len(list_collection))
@@ -88,9 +79,8 @@ class playlist(commands.Cog):
 
     @commands.command(name="deletefromplaylist", aliases=["dfp"], description="Delete song from playlist based on its number in the playlist.")
     @commands.has_any_role(*roles)
-    async def delete_from_playlist(self, ctx, value, *, playlist):
-        result = fileProcessing.delete_from_playlist(
-            ctx, playlist, int(value))
+    async def delete_from_playlist(self, ctx, value: int, *, playlist):
+        result = fileProcessing.delete_from_playlist(ctx, playlist, value)
         if result == "Done":
             await ctx.send("Song deleted from playlist.")
         elif result == "Not-Found":
@@ -102,27 +92,24 @@ class playlist(commands.Cog):
     @commands.has_any_role(*roles)
     async def create_playlist(self, ctx, *, playlist_name):
         player = self.bot.lavalink.player_manager.get(ctx.guild.id)
-        if player.is_playing:
-            songname = player.current.title
-            fileProcessing.new_playlist(ctx, playlist_name, songname)
-            await ctx.send(playlist_name + ", created.")
-        else:
-            await ctx.send("Please have the first song you want to add playing to make a new playlist.")
+        if not player or not player.is_playing:
+            return await ctx.send("Please have the first song you want to add playing to make a new playlist.")
+        songname = player.current.title
+        fileProcessing.new_playlist(ctx, playlist_name, songname)
+        await ctx.send(playlist_name + ", created.")
 
     @commands.command(name="addtoplaylist", aliases=["atp"], description="Adds currently playing song to the given playlist name as long as it exists.")
     @commands.has_any_role(*roles)
     async def add_to_playlist(self, ctx, *, playlist_name):
         player = self.bot.lavalink.player_manager.get(ctx.guild.id)
-        if player.is_playing:
-            songname = player.current.title
-            passfail = fileProcessing.add_to_playlist(
-                ctx, playlist_name, songname)
-            if passfail:
-                await ctx.send("Song added")
-            else:
-                await ctx.send("Playlist needs to be created before you can add to it.")
+        if not player or not player.is_playing:
+            return await ctx.send("Please have the first song you want to add playing to add it to the playlist.")
+        songname = player.current.title
+        passfail = fileProcessing.add_to_playlist(ctx, playlist_name, songname)
+        if passfail:
+            await ctx.send("Song added")
         else:
-            await ctx.send("Please have the first song you want to add playing to add it to the playlist.")
+            await ctx.send("Playlist needs to be created before you can add to it.")
 
     @commands.command(name="renameplaylist", aliases=["rpl"], description="Renames a current list. Input as: current name,new name")
     @commands.has_any_role(*roles)
@@ -139,16 +126,14 @@ class playlist(commands.Cog):
     @commands.has_any_role(*roles)
     async def add_queue_to_list(self, ctx, *, listname):
         player = self.bot.lavalink.player_manager.get(ctx.guild.id)
-        if player.is_playing:
-            songlist = player.queue
-            for song in songlist:
-                check = fileProcessing.add_to_playlist(
-                    ctx, listname, song.title)
-                if not check:
-                    return await ctx.send("Operation failed. Make sure the playlist name is valid.")
-            await ctx.send("Queue added to " + str(listname) + ".")
-        else:
+        if not player or not player.is_playing:
             raise commands.CommandInvokeError("There is nothing playing.")
+        songlist = player.queue
+        for song in songlist:
+            check = fileProcessing.add_to_playlist(ctx, listname, song.title)
+            if not check:
+                return await ctx.send("Operation failed. Make sure the playlist name is valid.")
+        await ctx.send("Queue added to " + str(listname) + ".")
 
 async def setup(bot):
     await bot.add_cog(playlist(bot))


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR addresses all findings from the master branch code review across 6 files.

### Bugs Fixed
- **`bot.py`** — `on_ready` now guards against double extension loading on reconnect using `if ext not in client.extensions`
- **`music.py`** — Competing auto-unpause loops prevented with a per-guild tracking set (`_auto_unpause_guilds`); a second `.pause` invocation now returns early instead of spawning a second loop
- **`music.py`** — Bare `except:` in `skip_song` replaced with `except Exception` to avoid swallowing `KeyboardInterrupt`/`SystemExit`
- **`playlist.py`** — Literal `'\n'` string in `listplaylists` pagination footer fixed to actual newline (`"\nPage: ..."`)
- **`fileProcessing.py`** — Redundant `open("w")` truncation in `rename_playlist` removed; now does a single read → pop → write
- **`playlist.py`** — `create_playlist`, `add_to_playlist`, `add_queue_to_list` now guard against `None` player before calling `player.is_playing`
- **`bot.py`** — `backupPlaylists` now checks `outcome.returncode` and reports failure instead of silently doing nothing

### Security
- **`music.py`** — Hardcoded Lavalink password `changeme123` removed; now loaded from `LAVALINK_PASSWORD` env var (with fallback). `.env.example` updated accordingly.

### Code Quality
- **`Cogs/cpu.py`** — `psutil.cpu_percent(interval=1)` was a 1-second blocking call on the async event loop; wrapped in `asyncio.to_thread`
- **`fileProcessing.py`** — `logUpdate` file handle now uses a `with` statement to guarantee close on exception
- **`fileProcessing.py`** — All bare `except:` clauses replaced with specific types (`FileNotFoundError`, `KeyError`, `json.JSONDecodeError`, `IndexError`, `OSError`)
- **`fileProcessing.py`** — Duplicated path construction extracted into `_playlist_path(ctx)` helper
- **`fileProcessing.py`** — `write_out` uses context manager; `add_to_playlist` uses `list.append` instead of `+= [item]`
- **`music.py`** — Hand-rolled shuffle replaced with `random.shuffle(player.queue)`
- **`music.py`** — `== False` replaced with `is False` in `play_from_list`
- **`playlist.py`** — Dead imports removed (`import re`, `url_rx`, `import lavalink`, `from discord import utils`)
- **`playlist.py`** — `view_playlist` now creates a fresh `Embed` per send instead of reusing the same object
- **`playlist.py`** — `deletefromplaylist` `value` parameter typed as `int` directly, removing manual `int()` cast
- **`Cogs/cpu.py`** — Dead import `from discord.utils import get` removed; typo "Permanant" fixed

## Test Plan
- [ ] Bot connects and loads all cogs cleanly on first start
- [ ] Bot reconnects (e.g. network blip) without `ExtensionAlreadyLoaded` errors
- [ ] `.play`, `.skip`, `.pause`, `.unpause`, `.clear`, `.shuffle`, `.removequeue` work as expected
- [ ] `.pause` called twice returns "already paused" on second invocation; auto-unpause fires after 7 min
- [ ] `.cpu` command responds without blocking other commands during the 1-second measurement
- [ ] Playlist commands (`.cpl`, `.atp`, `.vpl`, `.lpl`, `.rpl`, `.dpl`, `.dfp`) work correctly
- [ ] Lavalink connects using `LAVALINK_PASSWORD` from `.env`
- [ ] `.backupPlaylists` reports failure if zip fails

https://claude.ai/code/session_016nQNQ9sGiQxF1oS2fS7akE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016nQNQ9sGiQxF1oS2fS7akE)_